### PR TITLE
Enhance approval execution time export with detailed tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,186 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This repository provides practical examples for using the Concord API (https://api.doc.concordnow.com/). It contains standalone scripts demonstrating various Concord API use cases, primarily focused on agreement lifecycle management and data export.
+
+## Repository Structure
+
+The repository is organized into two main sections:
+
+- **`examples/`**: Contains comprehensive API walkthroughs and guides
+- **`scripts/`**: Contains executable examples organized by language:
+  - `scripts/javascript/`: Node.js scripts for various API operations
+  - `scripts/python/`: Python scripts for data export and analysis
+
+Each script is self-contained in its own directory with its own README, dependencies, and configuration.
+
+## API Configuration
+
+All scripts require a Concord API key for authentication:
+- Generate API keys at: https://secure.concordnow.com/#/automations/integrations
+- API keys are user-based and inherit the user's permissions
+- For organization-wide data access, use an API key from a user with appropriate permissions
+
+### Base URLs
+
+Scripts use different Concord environments:
+- **Production**: `api.concordnow.com` (default for most scripts)
+- **UAT/Testing**: `uat.concordnow.com` (used in some examples)
+
+## Common Development Tasks
+
+### JavaScript Scripts
+
+All JavaScript scripts use Node.js with native `https` module (no external HTTP libraries like `axios` or `node-fetch` v3+).
+
+**Install dependencies:**
+```bash
+cd scripts/javascript/<script-name>
+npm install
+```
+
+**Run a script:**
+```bash
+cd scripts/javascript/<script-name>
+node index.js
+```
+
+**Configuration pattern:**
+- Some scripts use inline API key configuration (e.g., `export-agreements-list`, `export-signers`): Edit `API_KEY` variable in `index.js` directly
+- Newer scripts use `config.json` pattern (e.g., `simple-draft-approval`): Copy `config.example.json` to `config.json` and edit values
+
+### Python Scripts
+
+Python scripts are designed for data export and analysis, typically outputting CSV files.
+
+**Setup virtual environment:**
+```bash
+cd scripts/python/<script-name>
+python3 -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+```
+
+**Install dependencies:**
+```bash
+pip install -r requirements.txt
+```
+
+**Run a script:**
+```bash
+python index.py
+```
+
+**Configuration pattern:**
+- API key configured directly in `index.py` file (look for `API_KEY = "YOUR_API_KEY_HERE"`)
+
+## Architecture Patterns
+
+### HTTP Request Pattern (JavaScript)
+
+All JavaScript scripts use a consistent pattern with native `https` module:
+
+```javascript
+function get(path) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      host: 'api.concordnow.com',
+      port: 443,
+      path: path,
+      headers: { "X-API-KEY": apiKey }
+    };
+    https.get(options, (res) => {
+      // Handle response with status checking
+      // Parse JSON from chunks
+    });
+  });
+}
+```
+
+Similar patterns exist for `post()`, `put()`, `delete()` methods where needed.
+
+### Pagination Pattern
+
+Concord API uses offset-based pagination. Scripts typically:
+1. Set a large `numberOfItemsByPage` parameter (e.g., 5000)
+2. Iterate through pages using `page` parameter (0-indexed)
+3. Continue until API returns empty results or fewer items than page size
+
+Example:
+```javascript
+const queryParams = [
+  "numberOfItemsByPage=5000",
+  `page=${pageNumber}`,
+  // ... other filters
+].join("&");
+```
+
+### Data Export Pattern (CSV)
+
+Export scripts follow this flow:
+1. Fetch organizations the API key has access to
+2. For each organization, fetch filtered agreements (by status, access type, etc.)
+3. For each agreement, fetch detailed data (activities, signatures, etc.)
+4. Build in-memory data structure
+5. Write timestamped CSV file with format: `export-{type}-YYYY-MM-DDTHH_MM_SS_MSZ.csv`
+
+### Agreement Status Filtering
+
+Concord agreements have various statuses. Key status groups:
+
+**Signing stage statuses** (used in export scripts):
+- `DRAFT`, `BROKEN`, `VALIDATION`, `NEGOTIATION`, `SIGNING`, `UNKNOWN_CONTRACT`, `FUTURE_CONTRACT`, `CURRENT_CONTRACT`, `COMPLETED_CONTRACT`, `COMPLETED_CANCEL_CONTRACT`, `COMPLETED_CONTRACT_RENEWABLE`
+
+**Fully signed statuses** (contract stage):
+- `UNKNOWN_CONTRACT`, `FUTURE_CONTRACT`, `CURRENT_CONTRACT`, `COMPLETED_CONTRACT`, `COMPLETED_CANCEL_CONTRACT`, `COMPLETED_CONTRACT_RENEWABLE`
+
+### Access Type Filtering
+
+When fetching agreements, scripts specify access types to control scope:
+- `DIRECT`: Direct access to specific agreements
+- `TAG`: Access via tags
+- `FOLDER`: Access via folder membership
+- `ORGANIZATION`: Full organization access
+
+## Key API Endpoints
+
+Based on the scripts in this repository:
+
+**User & Organization:**
+- `GET /api/rest/1/user/me` - Get current user info
+- `GET /api/rest/1/user/me/organizations` - List accessible organizations
+
+**Agreement Lifecycle:**
+- `POST /api/rest/1/organizations/{orgId}/agreements` - Create draft agreement
+- `POST /api/rest/1/organizations/{orgId}/auto/{templateUid}` - Create from automated template
+- `GET /api/rest/1/organizations/{orgId}/agreements/{uid}/metadata` - Get agreement metadata
+- `GET /api/rest/1/user/me/organizations/{orgId}/agreements` - List agreements (with filters)
+
+**Approval Workflow:**
+- `POST /api/rest/1/organizations/{orgId}/agreements/{uid}/approval` - Add custom approval
+- `POST /api/rest/1/organizations/{orgId}/agreements/{uid}/approval/accept` - Accept approval
+
+**Signatures:**
+- `PUT /api/rest/1/organizations/{orgId}/agreements/{uid}/signature/slots` - Set signature slots
+- `POST /api/rest/1/organizations/{orgId}/agreements/{uid}/signature/request` - Request signatures
+
+**Activities & Audit:**
+- `GET /api/rest/1/organizations/{orgId}/agreements/{uid}/activities` - Get audit trail
+
+**Document Export:**
+- `GET /api/rest/1/organizations/{orgId}/agreements/{uid}.pdf` - Download signed PDF
+
+## Agreement UIDs
+
+Agreements are identified by UIDs (e.g., `02yZQK4GBw1n95T9daJKx7`). These can be found:
+- In the Concord web interface URL: `https://secure.concordnow.com/#/organizations/{orgId}/agreements/{agreementUid}`
+- In API responses when creating or listing agreements
+
+## Security Notes
+
+- **Never commit API keys** - Configuration files with sensitive data are gitignored
+- **Respect rate limits** - Scripts use sequential processing to avoid overwhelming the API
+- **CSV output may contain sensitive data** - Secure exported files appropriately
+- **API keys are user-based** - They inherit permissions from the associated user account

--- a/scripts/python/export-approval-execution-time/README.md
+++ b/scripts/python/export-approval-execution-time/README.md
@@ -5,9 +5,11 @@ A Python script that exports all signed agreements from Concord API with complet
 ## Overview
 
 This script helps business analysts and contract administrators analyze agreement execution timelines by exporting:
-- Agreement creation date (from first activity in audit trail)
-- First and last approval dates
-- First and last signature dates
+- Agreement creation date and creator email (from first activity in audit trail)
+- Detailed approval information: up to 5 approvers with email addresses and dates
+- Detailed signature information: up to 5 signers with email addresses and dates
+- First and last approval/signature dates
+- Total counts of approvals and signatures
 
 The output is a timestamped CSV file ready for analysis in Excel, Google Sheets, or other spreadsheet applications.
 
@@ -126,28 +128,62 @@ You can now open the CSV file in Excel, Google Sheets, or any spreadsheet applic
 
 ## CSV Output Format
 
-### Columns
+### Columns (32 total)
 
-| Column | Description | Example Value | Empty If... |
-|--------|-------------|---------------|-------------|
-| Agreement ID | Unique identifier | `abc-123-def-456` | Never empty |
-| Agreement Title | Agreement name | `NDA with Acme Corp` | Never empty |
-| Agreement Link | Web URL to view | `https://secure.concordnow.com/#/organizations/{organizationId}/agreements/{agreementID}` | Never empty |
-| Creation Date | First activity timestamp from audit trail (UTC) | `2025-11-01 14:30:00` | Never empty |
-| First Approval Date | First approval timestamp (UTC) | `2025-11-02 09:15:00` | No approvals in workflow |
-| Last Approval Date | Last approval timestamp (UTC) | `2025-11-02 16:45:00` | No approvals in workflow |
-| First Signature Date | First signature timestamp (UTC) | `2025-11-03 10:00:00` | No signatures recorded |
-| Last Signature Date | Last signature timestamp (UTC) | `2025-11-03 14:30:00` | No signatures recorded |
+| Column # | Column Name | Description | Example Value | Empty If... |
+|----------|-------------|-------------|---------------|-------------|
+| 1 | Agreement ID | Unique identifier | `abc-123-def-456` | Never |
+| 2 | Agreement Title | Agreement name | `NDA with Acme Corp` | Never |
+| 3 | Agreement Link | Web URL to view | `https://secure.concordnow.com/#/...` | Never |
+| 4 | Creation Date | First activity timestamp (UTC) | `2025-11-01 14:30:00` | Never |
+| 5 | Created By | Email of user who created agreement | `john.doe@example.com` | Cannot determine |
+| 6 | Approver 1 | First approver email | `jane.smith@example.com` | No approvals |
+| 7 | Approval Date 1 | First approval timestamp (UTC) | `2025-11-02 09:15:00` | No approvals |
+| 8 | Approver 2 | Second approver email | `bob.johnson@example.com` | < 2 approvals |
+| 9 | Approval Date 2 | Second approval timestamp (UTC) | `2025-11-02 14:30:00` | < 2 approvals |
+| 10 | Approver 3 | Third approver email | `alice.brown@example.com` | < 3 approvals |
+| 11 | Approval Date 3 | Third approval timestamp (UTC) | `2025-11-02 16:45:00` | < 3 approvals |
+| 12 | Approver 4 | Fourth approver email | `charlie.davis@example.com` | < 4 approvals |
+| 13 | Approval Date 4 | Fourth approval timestamp (UTC) | `2025-11-03 08:00:00` | < 4 approvals |
+| 14 | Approver 5 | Fifth approver email | `diana.evans@example.com` | < 5 approvals |
+| 15 | Approval Date 5 | Fifth approval timestamp (UTC) | `2025-11-03 10:15:00` | < 5 approvals |
+| 16 | Signer 1 | First signer email | `carol.white@example.com` | No signatures |
+| 17 | Signature Date 1 | First signature timestamp (UTC) | `2025-11-04 09:00:00` | No signatures |
+| 18 | Signer 2 | Second signer email | `david.green@example.com` | < 2 signatures |
+| 19 | Signature Date 2 | Second signature timestamp (UTC) | `2025-11-04 14:30:00` | < 2 signatures |
+| 20 | Signer 3 | Third signer email | `emily.black@example.com` | < 3 signatures |
+| 21 | Signature Date 3 | Third signature timestamp (UTC) | `2025-11-04 16:45:00` | < 3 signatures |
+| 22 | Signer 4 | Fourth signer email | `frank.blue@example.com` | < 4 signatures |
+| 23 | Signature Date 4 | Fourth signature timestamp (UTC) | `2025-11-05 08:00:00` | < 4 signatures |
+| 24 | Signer 5 | Fifth signer email | `grace.red@example.com` | < 5 signatures |
+| 25 | Signature Date 5 | Fifth signature timestamp (UTC) | `2025-11-05 10:15:00` | < 5 signatures |
+| 26 | First Approval Date | First approval timestamp (UTC) | `2025-11-02 09:15:00` | No approvals |
+| 27 | Last Approval Date | Last approval timestamp (UTC) | `2025-11-03 10:15:00` | No approvals |
+| 28 | First Signature Date | First signature timestamp (UTC) | `2025-11-04 09:00:00` | No signatures |
+| 29 | Last Signature Date | Last signature timestamp (UTC) | `2025-11-05 10:15:00` | No signatures |
+| 30 | Total Approvals | Count of approval activities | `5` | `0` if no approvals |
+| 31 | Total Signatures | Count of signature activities | `5` | `0` if no signatures |
+
+### Column Groups
+- **Columns 1-5**: Basic agreement information
+- **Columns 6-15**: Detailed approval tracking (up to 5 approvers)
+- **Columns 16-25**: Detailed signature tracking (up to 5 signers)
+- **Columns 26-29**: First/last dates
+- **Columns 30-31**: Summary totals
 
 ### Example CSV Content
 
 ```csv
-Agreement ID,Agreement Title,Agreement Link,Creation Date,First Approval Date,Last Approval Date,First Signature Date,Last Signature Date
-abc-123-def-456,NDA with Acme Corp,https://secure.concordnow.com/#/organizations/org-123/agreements/abc-123-def-456,2025-11-01 14:30:00,2025-11-02 09:15:00,2025-11-02 16:45:00,2025-11-03 10:00:00,2025-11-03 14:30:00
-xyz-789-ghi-012,Service Agreement with Beta Inc,https://secure.concordnow.com/#/organizations/org-123/agreements/xyz-789-ghi-012,2025-10-15 10:00:00,,,2025-10-20 15:30:00,2025-10-21 11:00:00
+Agreement ID,Agreement Title,Agreement Link,Creation Date,Created By,Approver 1,Approval Date 1,Approver 2,Approval Date 2,Approver 3,Approval Date 3,Approver 4,Approval Date 4,Approver 5,Approval Date 5,Signer 1,Signature Date 1,Signer 2,Signature Date 2,Signer 3,Signature Date 3,Signer 4,Signature Date 4,Signer 5,Signature Date 5,First Approval Date,Last Approval Date,First Signature Date,Last Signature Date,Total Approvals,Total Signatures
+abc-123,NDA with Acme,https://...,2025-11-01 14:30:00,john@example.com,jane@example.com,2025-11-02 09:15:00,bob@example.com,2025-11-02 16:45:00,,,,,,,carol@example.com,2025-11-03 10:00:00,david@example.com,2025-11-03 14:30:00,,,,,,,2025-11-02 09:15:00,2025-11-02 16:45:00,2025-11-03 10:00:00,2025-11-03 14:30:00,2,2
+xyz-789,Service Agreement,https://...,2025-10-15 10:00:00,alice@example.com,,,,,,,,,,,emily@example.com,2025-10-20 15:30:00,frank@example.com,2025-10-21 11:00:00,,,,,,,,,2025-10-20 15:30:00,2025-10-21 11:00:00,0,2
 ```
 
-**Note**: Agreements without approval steps show empty strings in the approval date columns. This is expected behavior for agreements that skip the approval phase.
+**Notes**:
+- Agreements without approvals show empty strings in approval columns (6-15, 26-27)
+- Agreements without signatures show empty strings in signature columns (16-25, 28-29)
+- If more than 5 approvals or signatures exist, only the first 5 are shown (see Total columns for actual count)
+- Console warnings will alert you when agreements have >5 approvals or >5 signatures
 
 ## Troubleshooting
 
@@ -252,6 +288,21 @@ ERROR: Network request failed: /api/rest/1/...
    - Revoke old keys after rotation
 
 ## Known Limitations
+
+### Maximum 5 Approvers and 5 Signers Per Agreement
+
+The script exports **up to 5 approvers and 5 signers** per agreement.
+
+**Rationale**: Balances comprehensive data with reasonable CSV width. Most agreements have fewer than 5 approvals/signatures.
+
+**Impact**:
+- If an agreement has more than 5 approvals or signatures, only the first 5 (chronologically) are exported to individual columns
+- The "Total Approvals" and "Total Signatures" columns show the actual count, allowing you to identify agreements that exceeded the limit
+- Console warnings alert you when this occurs during export
+
+**Workaround**: Filter exported data by "Total Approvals" or "Total Signatures" > 5 to identify agreements needing special attention.
+
+---
 
 ### Fail-Fast Behavior
 

--- a/scripts/python/export-approval-execution-time/README.md
+++ b/scripts/python/export-approval-execution-time/README.md
@@ -128,7 +128,7 @@ You can now open the CSV file in Excel, Google Sheets, or any spreadsheet applic
 
 ## CSV Output Format
 
-### Columns (32 total)
+### Columns (31 total)
 
 | Column # | Column Name | Description | Example Value | Empty If... |
 |----------|-------------|-------------|---------------|-------------|

--- a/scripts/python/export-approval-execution-time/index.py
+++ b/scripts/python/export-approval-execution-time/index.py
@@ -3,11 +3,13 @@
 Export Signed Agreements with Approval and Execution Times
 
 This script exports all signed agreements from Concord API with complete timeline data:
-- Agreement creation date (from first activity in audit trail)
-- First and last approval dates
-- First and last signature dates
+- Agreement creation date and creator email (from first activity in audit trail)
+- Detailed approval tracking: up to 5 approvers with email addresses and dates
+- Detailed signature tracking: up to 5 signers with email addresses and dates
+- First and last approval/signature dates (for backward compatibility)
+- Total counts of approvals and signatures
 
-Output: Timestamped CSV file with agreement timeline data
+Output: Timestamped CSV file with 31 columns of agreement timeline data
 """
 
 # Configuration: Set your Concord API key here
@@ -541,7 +543,7 @@ def write_csv(filename, agreement_timelines):
     """
     Write agreement timeline data to CSV file.
 
-    CSV columns (32 total):
+    CSV columns (31 total):
     - Agreement ID, Title, Link, Creation Date, Created By
     - Approver 1-5, Approval Date 1-5 (10 columns)
     - Signer 1-5, Signature Date 1-5 (10 columns)
@@ -553,7 +555,7 @@ def write_csv(filename, agreement_timelines):
         filename: Output CSV filename
         agreement_timelines: List of timeline dictionaries
     """
-    # Define CSV headers (32 columns total - must match spec exactly)
+    # Define CSV headers (31 columns total - must match spec exactly)
     headers = [
         # Columns 1-5: Basics
         "Agreement ID",


### PR DESCRIPTION
## Summary

Enhances the `export-approval-execution-time` Python script to provide comprehensive approval and signature tracking for business analysts.

## Changes

### CSV Export Enhancement
- **Expanded from 8 to 32 columns** with detailed tracking:
  - Added "Created By" column (email of agreement creator)
  - Added detailed approval tracking: Approver 1-5 with emails and dates
  - Added detailed signature tracking: Signer 1-5 with emails and dates
  - Added total approval and signature counts
  - Maintained backward compatibility with first/last date columns

### Implementation Details
- New functions: `extract_created_by()`, `extract_detailed_approvals()`, `extract_detailed_signatures()`
- Updated `process_agreement()` to extract all new data
- Updated `write_csv()` to handle 32 columns
- Added console warnings when agreements have >5 approvals/signatures
- Correctly uses `creator.actor.email` API structure for email extraction

### Documentation
- Updated README.md with complete 32-column format documentation
- Added column groups explanation
- Added limitations section for 5 approver/signer maximum
- Updated example CSV output

## Testing Recommendations

Before deploying to production, test with:
- Agreement with 2-3 approvals and 2 signatures
- Agreement with no approvals (verify empty columns)
- Agreement with >5 approvals or >5 signatures (verify warning)
- Agreement with missing email data (verify empty strings, not errors)

## Backward Compatibility

✅ Existing columns 26-29 (First/Last Approval/Signature Dates) preserved
✅ No breaking changes - only additions
⚠️ Note: Reports referencing columns by index (not name) will need adjustment

## Customer Impact

Addresses all requirements from SUP-153:
- ✅ Detailed approver names (emails) and dates
- ✅ "Created By" field showing agreement creator
- ✅ Extended to signers with same pattern
- ✅ Clear warnings for truncated data

🤖 Generated with [Claude Code](https://claude.com/claude-code)